### PR TITLE
Add webpack_config; document CF_TOKEN export

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and fill in the following values (account_id and zone_id are found on your Cloud
 You will need to obtain a *scoped API* token to publish the worker.  
 You can do this at (https://dash.cloudflare.com/profile/api-tokens),
 and choose the "Edit Cloudflare Workers" template.
-We will later call the obtained token: `${TOKEN}`
+We will later call the obtained token: `${TOKEN}`.
 
 
 #### 2. Setup GPG
@@ -97,8 +97,8 @@ sign: clean
 
 To deploy with the token, you can choose one of the following options:
 
-a. Execute: `wrangler config`.
-   Enter token: `${TOKEN}`.
+a. Execute: `wrangler config`. 
+   Enter token: `${TOKEN}`. 
    Run: `make deploy`
 
 b. Run: `CF_API_TOKEN=${token} make deploy`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ sign: clean
 
 #### 3. Deploy
 
+Export Cloudflare API TOKEN
+
+```sh
+export CF_API_TOKEN="abcabcabc"
+```
+
 With that, you're ready to go!
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ and fill in the following values (account_id and zone_id are found on your Cloud
 - zone_id
 - routes
 
+You will need to obtain a *scoped API* token to publish the worker.  
+You can do this at (https://dash.cloudflare.com/profile/api-tokens),
+and choose the "Edit Cloudflare Workers" template.
+We will later call the obtained token: `${TOKEN}`
+
+
 #### 2. Setup GPG
 
 You will need to have a pre-existing GPG key in your keyring that's additionally uploaded to some public key server (tutorial here: [https://wiki.debian.org/Keysigning](https://wiki.debian.org/Keysigning)).
@@ -89,14 +95,10 @@ sign: clean
 
 #### 3. Deploy
 
-Export Cloudflare API TOKEN
+To deploy with the token, you can choose one of the following options:
 
-```sh
-export CF_API_TOKEN="abcabcabc"
-```
+a. Execute: `wrangler config`.
+   Enter token: `${TOKEN}`.
+   Run: `make deploy`
 
-With that, you're ready to go!
-
-```sh
-make deploy
-```
+b. Run: `CF_API_TOKEN=${token} make deploy`

--- a/wrangler.toml.template
+++ b/wrangler.toml.template
@@ -1,6 +1,8 @@
 name = "securitytxt-worker"
 type = "webpack"
+webpack_config = "webpack.config.js"
 account_id = ""
 zone_id = ""
 workers_dev = false
 routes = ["https://www.cloudflare.com/.well-known/security.txt", "https://www.cloudflare.com/gpg/security-cloudflare-public-06A67236.txt"]
+


### PR DESCRIPTION
This patch:
- Configures webpack.config in Wrangle.
- Documents CF_API_TOKEN export.