### PR TITLE
Add additional empty-line

### DIFF
--- a/src/expires.js
+++ b/src/expires.js
@@ -11,7 +11,7 @@ const main = async () => {
     `\nExpires: ${dayjs()
       .add(365, 'day')
       // Thu, 31 Dec 2020 18:37:07 -0800
-      .format('ddd, D MMM YYYY HH:mm:ss ZZ')}\n`,
+      .format('ddd, D MMM YYYY HH:mm:ss ZZ')}\n\n`,
     function(err) {
       if (err) throw err
       console.log('Wrote expiration field!')


### PR DESCRIPTION
This patch:
- Adds additional empty line for `Expire` field.

It improves readability.
Before:
![image](https://user-images.githubusercontent.com/50334623/77828898-8acefd00-711e-11ea-83e9-b62e196fc622.png)

After:
![image](https://user-images.githubusercontent.com/50334623/77828925-bce05f00-711e-11ea-8684-56a557bc6fd7.png)
