### PR TITLE
Fix formatting of `Expires` field according to security.txt draft 12

### DIFF
--- a/src/expires.js
+++ b/src/expires.js
@@ -10,8 +10,8 @@ const main = async () => {
     './src/txt/security.txt.temp',
     `\nExpires: ${dayjs()
       .add(365, 'day')
-      // Thu, 31 Dec 2020 18:37:07 -0800
-      .format('ddd, D MMM YYYY HH:mm:ss ZZ')}\n\n`,
+      // 2022-10-25T15:51:04.223Z
+      .toISOString()}\n\n`,
     function(err) {
       if (err) throw err
       console.log('Wrote expiration field!')


### PR DESCRIPTION
According to the most recent version of the Security.txt draft the `Expires` field should be an ISO 8601 string ([source](https://datatracker.ietf.org/doc/html/draft-foudil-securitytxt#section-3.5.5)). Also taking a look at example files in the official repository the values are also ISO 8601 strings ([source](https://github.com/securitytxt/security-txt/blob/master/draft-foudil-securitytxt.md#example-of-an-unsigned-securitytxt-file)).

The `dayjs().toISOString()` function is according to their [docs](https://day.js.org/docs/en/display/as-iso-string) ISO 8601 compatible. Also I've created a quick Codesandbox [here](https://codesandbox.io/s/wandering-wave-3fm31?file=/src/index.js) comparing the current output to the new one with the same minimum version of `dayjs`.